### PR TITLE
Proposed fix to some minor bugs in the full nightly report.

### DIFF
--- a/notebooks/nightly_report/nightly_report_ts_version.ipynb
+++ b/notebooks/nightly_report/nightly_report_ts_version.ipynb
@@ -19,9 +19,9 @@
    "outputs": [],
    "source": [
     "# Times Square Parameters\n",
-    "day_obs = 20250904\n",
-    "seq_min = 100\n",
-    "seq_max = 125"
+    "day_obs = 20251102\n",
+    "seq_min = 5\n",
+    "seq_max = 543"
    ]
   },
   {
@@ -634,7 +634,7 @@
     "                    [\"*\"],\n",
     "                    Time(rec_start, scale=\"utc\"),\n",
     "                    Time(rec_end, scale=\"utc\") + self.temp_time_window,\n",
-    "                    index=1,\n",
+    "                    index=121,\n",
     "                    convert_influx_index=True\n",
     "                )\n",
     "                temps_array = np.array(\n",
@@ -928,8 +928,7 @@
     "    axes[0].set_title(f'Optical Aberrations')\n",
     "    \n",
     "    \n",
-    "    plt.tight_layout(rect=[0, 0, 1, 1])\n",
-    "    fig.suptitle(\"Survey Mode Performance Simplified – Day \" + str(day_obs), fontsize=18, y=1.03)\n",
+    "    fig.suptitle(\"Survey Mode Performance Simplified – Day \" + str(day_obs), fontsize=18, x=0.35, y=1.03)\n",
     "else:\n",
     "    print('No data to plot')"
    ]
@@ -1069,7 +1068,7 @@
     "    axes[2].scatter(filtered_table['seq'], filtered_table['cam_hex_m1m3_delta_t'], color='k', s=3)\n",
     "    axes[3].scatter(filtered_table['seq'], filtered_table['dome_delta_t'], color='k', s=3)\n",
     "    \n",
-    "    axes[0].set_ylabel(f'M1M3 $\\Delta T$\\n[C]')\n",
+    "    axes[0].set_ylabel(f'M1M3 $Delta T$\\n[C]')\n",
     "    axes[1].set_ylabel('M2 - amb\\n[C]')\n",
     "    axes[2].set_ylabel('Cam - M1M3\\n[C]')\n",
     "    axes[3].set_ylabel('In - Out\\n[C]')\n",
@@ -1123,7 +1122,6 @@
     "    axes[0].set_title(f'Hexapods State (LUT + trim)')\n",
     "    axes[-1].set_xlabel(\"Sequence Number\")\n",
     "    \n",
-    "    plt.tight_layout(rect=[0, 0, 1, 1])\n",
     "    fig.suptitle(\"Survey Mode Performance and AOS DoFs – Day \" + str(day_obs), fontsize=18, x=0.35, y=1.03)\n",
     "else:\n",
     "    print('No data to plot')"
@@ -1154,7 +1152,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The full night report has been failing in TimeSquare I made four minor changes
(1) I think salIndex for camHex temp data should be 121.
(2) I think tightlayout is not needed with GridSpec.  Eliminating it removed some warnings.
(3) Centered title on Simplified night report.
(4) re,oved a backslash that didn't belong in DeltaT label.